### PR TITLE
Refine about blurb tone

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,8 +89,11 @@
         </h1>
         <div class="subheading mb-5">
         </div>
-        <p class="lead mb-5">Besides being an upcoming IT specialist, I like dancing, music, composing and beekeeping.
-        </p>
+        <p class="lead mb-5">I’m an IT Automation Engineer at TTTech Computertechnik AG shaping process-driven,
+          scalable workflows across PowerShell, Python, Groovy, and Azure Automation, Logic Apps, and Power Automate,
+          grounded in hands-on work with CrowdStrike, Exchange, Microsoft Graph, Tenable.io, and Xurrent. Away from the
+          office I contribute to multi-language automation projects and unwind with motorcycle rides, water skiing, and the
+          cadence of MotoGP and Formula&nbsp;1—moving with the quiet assurance of someone who knows every corridor of the manor.</p>
         <div class="social-icons">
           <a href="https://www.linkedin.com/in/fabian-steiner-574111318/" target="_blank">
             <i class="fab fa-linkedin"></i>
@@ -690,6 +693,17 @@
             target="_blank">Engineer Certifications WKO</a>
         </li>
         <li>
+          <i class="fa-li fa fa-trophy text-warning"></i>
+          Xurrent Automation Rules Certification <a
+            href="download/Certificate%20Xurrent%20Automation%20Rules%20(for%20Absorb).pdf" target="_blank">View
+            certificate</a>
+        </li>
+        <li>
+          <i class="fa-li fa fa-trophy text-warning"></i>
+          Xurrent Administrator Level&nbsp;2-A Certification <a
+            href="download/Certificate%20Xurrent%20Administrator%20Level%202-A.pdf" target="_blank">View
+            certificate</a>
+        </li>
         <li>
           <i class="fa-li fa fa-trophy text-warning"></i>
           IPMA Level D (certified Junior Project Manager)
@@ -745,6 +759,10 @@
             Reference FCP 2016 in German</a></li>
         <li><a href="download/Praktikumszeugnis_TTTech_2015.pdf" class="reference-link" target="_blank">Employers
             Reference TTTech 2015 in German</a></li>
+        <li><a href="download/Certificate%20Xurrent%20Automation%20Rules%20(for%20Absorb).pdf" class="btn btn-default"
+            target="_blank">Xurrent Automation Rules Certification</a></li>
+        <li><a href="download/Certificate%20Xurrent%20Administrator%20Level%202-A.pdf" class="btn btn-default"
+            target="_blank">Xurrent Administrator Level&nbsp;2-A Certification</a></li>
       </ul>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -91,9 +91,9 @@
         </div>
         <p class="lead mb-5">I’m an IT Automation Engineer at TTTech Computertechnik AG shaping process-driven,
           scalable workflows across PowerShell, Python, Groovy, and Azure Automation, Logic Apps, and Power Automate,
-          grounded in hands-on work with CrowdStrike, Exchange, Microsoft Graph, Tenable.io, and Xurrent. Away from the
-          office I contribute to multi-language automation projects and unwind with motorcycle rides, water skiing, and the
-          cadence of MotoGP and Formula&nbsp;1—moving with the quiet assurance of someone who knows every corridor of the manor.</p>
+          grounded in hands-on work with CrowdStrike, Exchange, Microsoft Graph, Tenable.io, and Xurrent. Outside of
+          work I dive into multi-language automation projects and find balance in the rush of motorcycles, the splash
+          of water skiing, and the rhythm of MotoGP and Formula 1.</p>
         <div class="social-icons">
           <a href="https://www.linkedin.com/in/fabian-steiner-574111318/" target="_blank">
             <i class="fab fa-linkedin"></i>


### PR DESCRIPTION
## Summary
- soften the About section blurb to maintain a refined tone while highlighting automation expertise and personal interests

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6961898b48322bbf61a7fb910fcf7